### PR TITLE
Add additional check to avoid negative values for q

### DIFF
--- a/scripts/avifenc.py
+++ b/scripts/avifenc.py
@@ -70,7 +70,7 @@ def encode_avif(printProgress=False, maxFileSizeKb = 32):
                 image.save(outputPath, quality=int(q))
                 if terminate:
                     # there was a rounding error caused by np.ceil() so just one more optimization step is needed
-                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb:
+                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb and q > minQ:
                         q = q - 1
                         image.save(outputPath, quality=int(q))
                     break

--- a/scripts/bpgenc.py
+++ b/scripts/bpgenc.py
@@ -66,7 +66,7 @@ def encode_bpg(printProgress=False, maxFileSizeKb = 32):
                 os.system('bpgenc -o ' + outputPath + ' -q ' + str(int(maxQ - q)) + ' ' + image_path)
                 if terminate:
                     # there was a rounding error caused by np.ceil() so just one more optimization step is needed
-                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb:
+                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb and q > minQ:
                         q = q - 1
                         os.system('bpgenc -o ' + outputPath + ' -q ' + str(int(maxQ - q)) + ' ' + image_path)
                     break

--- a/scripts/heicEnc.py
+++ b/scripts/heicEnc.py
@@ -69,7 +69,7 @@ def encode_heic(printProgress=False, maxFileSizeKb = 32):
                 image.save(outputPath, quality=int(q))
                 if terminate:
                     # there was a rounding error caused by np.ceil() so just one more optimization step is needed
-                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb:
+                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb and q > minQ:
                         q = q - 1
                         image.save(outputPath, quality=int(q))
                     break

--- a/scripts/jpegxl.py
+++ b/scripts/jpegxl.py
@@ -70,7 +70,7 @@ def encode_jpgxl(printProgress=False, maxFileSizeKb = 32):
                 # save image with new quality
                 subprocess.call(['cjxl', image_path, outputPath, '--quiet', '-q', str(q)])
                 if terminate:
-                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb:
+                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb and q > minQ:
                         #ML: decrease quality by 1 to get under threshold again and to set q to the last valid value
                         q = q - 1
                         subprocess.call(['cjxl', image_path, outputPath, '--quiet', '-q', str(q)])

--- a/scripts/preprocessing.py
+++ b/scripts/preprocessing.py
@@ -9,7 +9,7 @@ import jpegxl
 from concurrent.futures import ThreadPoolExecutor
 
 
-async def preprocess(cropNeeded=True,
+async def preprocess(cropNeeded=False,
                      width=512,
                      height=512,
                      maxFileSizeKb=32,

--- a/scripts/webP.py
+++ b/scripts/webP.py
@@ -67,7 +67,7 @@ def encode_webp(printProgress=False, maxFileSizeKb = 32):
                 # save image with new quality
                 image.save(outputPath, quality=int(q))
                 if terminate:
-                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb:
+                    if os.path.getsize(outputPath) / 1024 > maxFileSizeKb and q > minQ:
                         #ML: decrease quality by 1 to get under threshold again and to set q to the last valid value
                         q = q - 1
                         image.save(outputPath, quality=int(q))


### PR DESCRIPTION
Tested it with max file size 0.1. @m-langer now you can rerun the preprocessing script after merging it 😄 

![image](https://user-images.githubusercontent.com/116754128/235722818-84fa32b0-2db1-4249-9308-785e0e66fbe2.png)

But please test it before you merge it, because jxr can make problems with to low file sizes, since the quantization gets then to low.... If it happens please et me know and I remove that part that does the additional quantization step. (But without it, jxr has a very bad compression ratio)
Thats happening with 0.1 but 5kb worked good for me:
![image](https://user-images.githubusercontent.com/116754128/235723827-7fcbdcf8-e362-4309-b4a8-944f7eee535c.png)
